### PR TITLE
mining: Fix regtest mining difficulty

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -596,9 +596,9 @@ public:
             consensus.vDeployments[deployment_pos].min_activation_height = version_bits_params.min_activation_height;
         }
 
-        genesis = CreateGenesisBlock(1750495460, 3948631054, 0x1d00ffff, 1, 50 * COIN);
+        genesis = CreateGenesisBlock(1750495460, 3948631054, 0x207fffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256{"00000000379eca4e51372f2b154c8287e189c461335a8b98aff26eeb74bca0a4"});
+        assert(consensus.hashGenesisBlock == uint256{"0773b918b3ed43e74c8c715d0f950d3cfe909b6b3bea5f47b2435938824199a9"});
         assert(genesis.hashMerkleRoot == uint256{"80d1b4e9ca868f83b88b9301036205876072bdd3ded0ad4dc022e1f9266ddc49"});
 
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
@@ -610,7 +610,7 @@ public:
 
         checkpointData = {
             {
-                {0, uint256{"00000000379eca4e51372f2b154c8287e189c461335a8b98aff26eeb74bca0a4"}},
+                {0, uint256{"0773b918b3ed43e74c8c715d0f950d3cfe909b6b3bea5f47b2435938824199a9"}},
             }
         };
 

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -24,8 +24,18 @@ class RPCGenerateTest(BitcoinIITestFramework):
         self.test_generateblock()
 
     def test_generatetoaddress(self):
-        self.generatetoaddress(self.nodes[0], 1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
-        assert_raises_rpc_error(-5, "Invalid address", self.generatetoaddress, self.nodes[0], 1, '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
+        node = self.nodes[0]
+
+        self.log.info("Test repeated regtest generatetoaddress calls")
+        start_height = node.getblockcount()
+        address = node.get_deterministic_priv_key().address
+        for expected_height in range(start_height + 1, start_height + 4):
+            generated_blocks = self.generatetoaddress(node, 1, address)
+            assert_equal(len(generated_blocks), 1)
+            assert_equal(node.getblockcount(), expected_height)
+
+        self.generatetoaddress(node, 1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
+        assert_raises_rpc_error(-5, "Invalid address", self.generatetoaddress, node, 1, '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
 
     def test_generateblock(self):
         node = self.nodes[0]


### PR DESCRIPTION
## Problem summary

BitcoinII Core v29.1.0 can mine the first regtest block with `generatetoaddress`, but later `generatetoaddress` calls return an empty block list. This makes regtest unreliable for automated wallet and swap tests because coinbase funds cannot be matured and follow-up transactions cannot be confirmed predictably.

## Reproduction steps

Using the stock BitcoinII Core v29.1.0 Windows CLI release:

1. Start `bitcoinIId` on regtest with wallet/RPC enabled.
2. Create/load a wallet and get a regtest address.
3. Run `generatetoaddress 1 <address> 100000000`.
4. Run the same command again.
5. Observe that the first call returns one block hash, while later calls return `[]`, even with the high `maxtries` value.

The reproduction/validation helper used for this is available from the BasicSwap BC2 integration work as `scripts/probe_bitcoinii_regtest.py`.

## Root cause

Regtest is configured for easy local mining:

- `powLimit = 7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff`
- `fPowAllowMinDifficultyBlocks = true`
- `fPowNoRetargeting = true`
- `m_is_mockable_chain = true`

However, the regtest genesis block is created with the harder compact target `0x1d00ffff`. Since regtest disables retargeting, that hard target appears to carry forward after genesis, making subsequent blocks impractical to mine through normal regtest commands.

## Scope of this change

This changes only regtest chain parameters in `src/kernel/chainparams.cpp`:

- regtest genesis `nBits`: `0x1d00ffff` -> `0x207fffff`
- expected regtest genesis hash assertion updated to the hash produced by that regtest-only genesis target
- regtest height-0 checkpoint updated to the same hash

No mainnet or testnet consensus parameters are changed.

This also adds a minimal regression check to the existing default functional test `test/functional/rpc_generate.py`:

- three consecutive regtest `generatetoaddress` calls must each return one block
- each call must advance the chain height by one

No new test file or test-runner entry is added.

## Validation results

Patch application and local checks:

- Verified the original patch applies cleanly to current `origin/main` (`0c89479`).
- Ran `git diff --check origin/main..HEAD`; no whitespace issues.
- Confirmed the branch changes only:
  - `src/kernel/chainparams.cpp`
  - `test/functional/rpc_generate.py`

Patched binary validation on Windows with BitcoinII Core v29.1.0 daemon/CLI:

- `getdescriptorinfo` and `importdescriptors` are available.
- `getdeploymentinfo` lists `csv`, `segwit`, and `taproot`.
- descriptor import into a private-key-disabled watch wallet succeeds.
- three consecutive `generatetoaddress` calls mined blocks at heights 1, 2, and 3.
- `repeat_mining_ok: true`.

Optional mature watch-funds probe also passed:

- mined 100 additional regtest blocks after the initial three probe blocks.
- watch-only wallet reported `watch_received_by_address_minconf_1: 150.00000000`.
- watch-only wallet reported trusted balance `150.00000000`.
- final chain height: `103`.

Regression test validation:

- `py_compile` for `test/functional/rpc_generate.py` passed.
- `test/functional/rpc_generate.py` passed locally with patched binaries and a fresh functional-test cache: `python test/functional/rpc_generate.py --configfile=C:\bcli\test\config.ini --cachedir=<fresh-cache>`.

The first local functional-test attempt with the default cache failed during framework setup because the existing cache was incompatible with the changed regtest genesis. Rerunning with a fresh cache passed.

## Why this matters for BasicSwap BC2 integration tests

BasicSwap DEX integration tests need deterministic regtest block generation to mature test funds, confirm lock/redeem/refund transactions, and validate BitcoinII / BC2 swap behavior against Particl. Without repeated regtest mining, BC2 can pass descriptor/watch-only capability checks but cannot reliably complete automated daemon-backed swap tests.

This regtest-only fix removes that Core-side blocker while leaving production networks untouched.
